### PR TITLE
Fix for preparedStatementCache on different schemas

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,12 +4,12 @@
 
   <parent>
     <groupId>org.avaje</groupId>
-    <artifactId>oss-parent</artifactId>
+    <artifactId>java8-parent</artifactId>
     <version>1.1</version>
   </parent>
 
   <artifactId>avaje-datasource</artifactId>
-  <version>1.1.5-SNAPSHOT</version>
+  <version>2.1.1-SNAPSHOT</version>
 
   <scm>
     <connection>scm:git:https://github.com/ebean-orm/avaje-datasource.git</connection>
@@ -19,7 +19,7 @@
   </scm>
   
   <properties>
-    <java.version>1.6</java.version>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,14 @@
       <scope>test</scope>
     </dependency>
 
+    <!-- Override com.h2database version to get schema support -->    
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <version>1.4.193</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/src/main/java/org/avaje/datasource/delegate/ConnectionDelegator.java
+++ b/src/main/java/org/avaje/datasource/delegate/ConnectionDelegator.java
@@ -8,6 +8,8 @@ import java.util.concurrent.Executor;
 public class ConnectionDelegator implements Connection {
 
   private final Connection delegate;
+  
+  protected String currentSchema;
 
   public ConnectionDelegator(Connection delegate) {
     this.delegate = delegate;
@@ -23,6 +25,7 @@ public class ConnectionDelegator implements Connection {
   @Override
   public void setSchema(String schema) throws SQLException {
     delegate.setSchema(schema);
+    currentSchema = schema;
   }
 
   @Override

--- a/src/main/java/org/avaje/datasource/pool/PooledConnection.java
+++ b/src/main/java/org/avaje/datasource/pool/PooledConnection.java
@@ -363,15 +363,21 @@ public class PooledConnection extends ConnectionDelegator {
    * This will try to use a cache of PreparedStatements.
    */
   public PreparedStatement prepareStatement(String sql, int returnKeysFlag) throws SQLException {
-    String cacheKey = sql + returnKeysFlag;
-    return prepareStatement(sql, true, returnKeysFlag, cacheKey);
+    StringBuilder cacheKey = new StringBuilder(sql.length() + 50);
+    cacheKey.append(sql);
+    cacheKey.append(':').append(currentSchema);
+    cacheKey.append(':').append(returnKeysFlag);
+    return prepareStatement(sql, true, returnKeysFlag, cacheKey.toString());
   }
 
   /**
    * This will try to use a cache of PreparedStatements.
    */
   public PreparedStatement prepareStatement(String sql) throws SQLException {
-    return prepareStatement(sql, false, 0, sql);
+    StringBuilder cacheKey = new StringBuilder(sql.length() + 50);
+    cacheKey.append(sql);
+    cacheKey.append(':').append(currentSchema);
+    return prepareStatement(sql, false, 0, cacheKey.toString());
   }
 
   /**


### PR DESCRIPTION
Hello Rob,

I want to provide a fix for the preparedStatementCache recognizing schema switch.

After I solved this bug: https://groups.google.com/forum/#!topic/h2-database/eJGE-CD_qhk I ran into the next problem... I got a cached prepared statement for the wrong tenant.
According to https://docs.oracle.com/javase/7/docs/api/java/sql/Connection.html#setSchema(java.lang.String) "Calling setSchema has no effect on previously created or prepared Statement objects." this gave me datas from the wrong tenant.

I also increased major version because I changed the project to be a java 8 child.

cheers
Roland