### PR TITLE
Changed the following things

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>org.avaje</groupId>
       <artifactId>avaje-datasource-api</artifactId>
-      <version>3.2</version>
+      <version>3.3-FOC2</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
- initSql can execute statements, when opening a new connection
- with 'failOnStart' you can control the start up behaviour, if DB server is not reachable e.g.
- changes in the DataSourceAlert API

Waiting for  https://github.com/ebean-orm/avaje-datasource-api/pull/3 to be merged and released